### PR TITLE
Remove hardcoded debug args

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,10 +37,7 @@ function startClient(dir: string) {
     }
 
     let serverPath = 'elm-language-server';
-    let debugArgs = [
-            '--server-log-file', 'c:/dev/elm-lsp-log.txt',
-            '--session-log-file', 'c:/dev/elm-lsp-log-session.txt'
-        ];
+    let debugArgs: string[] = [];
     // If the extension is launched in debug mode then the debug server options are used
     // Otherwise the run options are used
     let serverOptions: ServerOptions = {


### PR DESCRIPTION
Remove `'c:/dev/elm-lsp-log.txt'` because not on every OS.